### PR TITLE
Add a null check for InteropObject

### DIFF
--- a/Darnton.Blazor.Leaflet/InteropObject.cs
+++ b/Darnton.Blazor.Leaflet/InteropObject.cs
@@ -40,7 +40,8 @@ namespace Darnton.Blazor.Leaflet
         /// <inheritdoc/>
         public async ValueTask DisposeAsync()
         {
-            await JSObjectReference.DisposeAsync();
+            if (JSObjectReference != null)
+                await JSObjectReference.DisposeAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
Prevents a nullreferenceexception when such an object is disposed before the JS reference is acquired (in case of a quick page redirect, the case happened to me).